### PR TITLE
Make the daemon umask configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -125,6 +125,7 @@ default['os-hardening']['security']['suid_sgid']['dry_run_on_unknown']  = false
 default['os-hardening']['security']['init']['prompt']                   = true
 # Require root password for single user mode. (rhel, centos)
 default['os-hardening']['security']['init']['single']                   = false
+default['os-hardening']['security']['init']['daemon_umask']             = '027'
 
 # remove packages with known issues
 default['os-hardening']['security']['packages']['clean']               = true

--- a/recipes/sysctl.rb
+++ b/recipes/sysctl.rb
@@ -166,7 +166,8 @@ when 'rhel', 'fedora', 'amazon'
     group 'root'
     variables(
       prompt: node['os-hardening']['security']['init']['prompt'],
-      single: node['os-hardening']['security']['init']['single']
+      single: node['os-hardening']['security']['init']['single'],
+      umask: node['os-hardening']['security']['init']['daemon_umask']
     )
   end
 end

--- a/templates/default/rhel_sysconfig_init.erb
+++ b/templates/default/rhel_sysconfig_init.erb
@@ -31,4 +31,4 @@ ACTIVE_CONSOLES=/dev/tty[1-6]
 SINGLE=<%= @single ? '/sbin/sulogin' : '/sbin/sushell' %>
 
 # NSA 2.2.4.1 Set Daemon umask
-umask 027
+umask <%= @umask %>


### PR DESCRIPTION
With the `node['os-hardening']['security']['init']['daemon_umask']` attribute.
Defaults to `027`, the original value set by the recipe.